### PR TITLE
Remove `LEAD q`

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -887,11 +887,6 @@ void matrix_scan_user(void) {
     }
 #endif
 
-    SEQ_ONE_KEY (KC_Q) {
-      register_code16 (LCTL(KC_1));
-      unregister_code16 (LCTL(KC_1));
-    }
-
     SEQ_ONE_KEY (KC_T) {
       time_travel = !time_travel;
     }


### PR DESCRIPTION
This sequence does nothing useful, and was - as it seems - just a test for `register_code16`. Drop it, so it won't send other people on a journey to find out what it is supposed to do...